### PR TITLE
Add Factory repository contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+This repository contains educational OCaml implementations of common data structures and algorithms.
+
+## Agent Rules
+
+- Keep changes small and easy to review.
+- Prefer clear, idiomatic OCaml over clever code.
+- Preserve the educational style of the repository.
+- Run `make test` after code changes when the local OCaml toolchain is available.
+- Do not change the project license without human review.
+- Do not push directly to `master`.
+- Do not merge pull requests.
+
+## Existing Notes
+
+Read `CLAUDE.md` before making code changes.
+It contains repository-specific build and architecture notes.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,8 @@
+# JOURNAL.md
+
+## 2026-06-29
+
+- Added the initial Factory repository contract.
+- First workflow target is `standards-check`.
+- Known issue for agent review: `LICENSE` and `README.md` say MIT, while `ods.opam` says Apache-2.0.
+- License changes require human review.

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -1,0 +1,46 @@
+# STANDARDS.md
+
+This file defines the repository standards that Factory agents should enforce.
+
+## Project Purpose
+
+The repository should remain an educational OCaml library of data structures and algorithms.
+Examples, names, and tests should help readers understand the implementation.
+
+## Required Files
+
+- `LICENSE` must exist.
+- `README.md` must explain the project purpose, build commands, test commands, usage, and project structure.
+- `CLAUDE.md` or `AGENTS.md` must explain how agents should work in the repo.
+- `dune-project` and `ods.opam` must stay aligned with the build system.
+
+## License
+
+- License metadata in `README.md`, `LICENSE`, and `ods.opam` must agree.
+- Changing the license requires human review.
+
+## OCaml Code
+
+- Code should be readable and idiomatic OCaml.
+- Prefer small functions and clear pattern matching.
+- Keep public module names stable unless a human approves an API change.
+- Avoid broad rewrites when a targeted fix is enough.
+
+## Tests
+
+- Code changes should include or update tests when behavior changes.
+- `make test` should pass before opening a pull request when the local OCaml toolchain is available.
+- If tests cannot run locally, the pull request must explain why.
+
+## Documentation
+
+- README examples should compile or clearly be marked as pseudo-code.
+- Document any new data structure or algorithm in `README.md`.
+- Keep docs aligned with files that actually exist in the repo.
+
+## Pull Requests
+
+- Use a non-default branch.
+- Open draft pull requests for agent-created changes.
+- Include a short summary, verification steps, and remaining gaps.
+- Never merge pull requests automatically.

--- a/WORKFLOWS/standards-check.md
+++ b/WORKFLOWS/standards-check.md
@@ -1,0 +1,60 @@
+# Standards Check
+
+## Goal
+
+Review this repository against `STANDARDS.md`.
+Make the smallest safe change that improves compliance.
+
+## Inputs
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `STANDARDS.md`
+- `JOURNAL.md`, when present
+- current git status
+- current test and build files
+- current README and docs
+
+## Plan Mode
+
+In plan mode:
+
+1. Read `AGENTS.md`, `CLAUDE.md`, and `STANDARDS.md`.
+2. Compare the repository against each standard.
+3. Report which standards pass, fail, or need human review.
+4. Name one smallest safe change for execute mode.
+5. Do not edit files.
+6. Do not create a branch.
+7. Do not open a pull request.
+
+## Execute Mode
+
+In execute mode:
+
+1. Read `AGENTS.md`, `CLAUDE.md`, and `STANDARDS.md`.
+2. Pick one small fix that does not need human review.
+3. Create a non-default branch named `factory/standards-check-<short-description>`.
+4. Make the change.
+5. Run `make test` when the OCaml toolchain is available.
+6. Commit the change.
+7. Push the branch.
+8. Open a draft pull request.
+9. Include what changed, what was checked, and any remaining gaps.
+
+## Stop Rules
+
+Stop and report `blocked` if:
+
+- the standard requires a human product or license decision
+- tests cannot run because required dependencies, secrets, or services are missing
+- the fix would change public behavior beyond the workflow scope
+- the working tree already has unrelated user changes
+- the repo has no clear default branch or remote
+
+## Safety
+
+- Never merge a pull request.
+- Never push to `master`.
+- Never do broad cleanup.
+- Never change the license without human review.
+- Prefer one small pull request over many unrelated fixes.


### PR DESCRIPTION
## Summary
- Add AGENTS.md for repo-specific agent instructions
- Add STANDARDS.md for Factory-enforced repo standards
- Add WORKFLOWS/standards-check.md as the first runnable Factory workflow
- Add JOURNAL.md with initial handover notes

## Verification
- make test

## Notes
- The standards intentionally flag license metadata alignment as human-reviewed because LICENSE and README.md say MIT while ods.opam says Apache-2.0.